### PR TITLE
[#25] move external url from `concourse-ci.org` to `pivotal.io`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HELM_HOME ?= $(shell helm home)
 # Generates the `deploy` pipeline [1] based on the
 # `jsonnet` file under `ci`.
 #
-# [1]: https://hush-house.concourse-ci.org/teams/main/pipelines/deploy
+# [1]: https://hush-house.pivotal.io/teams/main/pipelines/deploy
 #
 deploy-pipeline: ci/deploy.json
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 <br />
 
 
-This repository contains the configuration of [hush-house.concourse-ci.org](https://hush-house.concourse-ci.org), [metrics-hush-house.concourse-ci.org](https://metrics-hush-house.concourse-ci.org), and any other [Kubernetes (K8S)](https://kubernetes.io/docs/concepts/overview/what-is-kubernetes/) deployments using the `hush-house` Kubernetes cluster available in the shared Concourse [Google Cloud](https://cloud.google.com/) account.
+This repository contains the configuration of [hush-house.pivotal.io](https://hush-house.pivotal.io), [metrics-hush-house.concourse-ci.org](https://metrics-hush-house.concourse-ci.org), and any other [Kubernetes (K8S)](https://kubernetes.io/docs/concepts/overview/what-is-kubernetes/) deployments using the `hush-house` Kubernetes cluster available in the shared Concourse [Google Cloud](https://cloud.google.com/) account.
 
 <br />
 

--- a/deployments/README.md
+++ b/deployments/README.md
@@ -1,6 +1,6 @@
 # Deployments
 
-Here's where you can find all of the deployments that are picked up by `hush-house` to deploy in the `hush-house` cluster using the [`deploy` pipeline](https://hush-house.concourse-ci.org/teams/main/pipelines/deploy).
+Here's where you can find all of the deployments that are picked up by `hush-house` to deploy in the `hush-house` cluster using the [`deploy` pipeline](https://hush-house.pivotal.io/teams/main/pipelines/deploy).
 
 Each deployment directory is meant to be a [Helm Chart](https://github.com/helm/helm/blob/master/docs/charts.md), supposed to be continuously deployed in the form of releases.
 

--- a/deployments/with-creds/Makefile
+++ b/deployments/with-creds/Makefile
@@ -30,7 +30,6 @@ diff-%: | ensure-creds-file-exists-% deps-%
 			--namespace=$* \
 			--detailed-exitcode \
 			--values=./.values.yaml \
-			--set=concourse.web.annotations.time=`date +%s` \
 			$(HELM_FLAGS) \
 			$* \
 			.
@@ -41,10 +40,8 @@ template-%: | ensure-creds-file-exists-% deps-%
 		helm template \
 		--name=$* \
 		--values=./.values.yaml \
-		--set=concourse.web.annotations.time=`date +%s` \
 		$(HELM_FLAGS) \
 		.
-
 
 
 deploy-%: | ensure-creds-file-exists-% deps-%
@@ -55,7 +52,6 @@ deploy-%: | ensure-creds-file-exists-% deps-%
 			--namespace=$* \
 			--timeout=900 \
 			--values=./.values.yaml \
-			--set=concourse.web.annotations.time=\"`date +%s`\" \
 			--wait \
 			$(HELM_FLAGS) \
 			$* \

--- a/deployments/with-creds/Makefile
+++ b/deployments/with-creds/Makefile
@@ -30,6 +30,7 @@ diff-%: | ensure-creds-file-exists-% deps-%
 			--namespace=$* \
 			--detailed-exitcode \
 			--values=./.values.yaml \
+			--set=concourse.web.annotations.time=`date +%s` \
 			$(HELM_FLAGS) \
 			$* \
 			.
@@ -40,6 +41,7 @@ template-%: | ensure-creds-file-exists-% deps-%
 		helm template \
 		--name=$* \
 		--values=./.values.yaml \
+		--set=concourse.web.annotations.time=`date +%s` \
 		$(HELM_FLAGS) \
 		.
 
@@ -53,6 +55,7 @@ deploy-%: | ensure-creds-file-exists-% deps-%
 			--namespace=$* \
 			--timeout=900 \
 			--values=./.values.yaml \
+			--set=concourse.web.annotations.time=\"`date +%s`\" \
 			--wait \
 			$(HELM_FLAGS) \
 			$* \

--- a/deployments/with-creds/hush-house/README.md
+++ b/deployments/with-creds/hush-house/README.md
@@ -12,6 +12,7 @@ It relies solely on the release-candidate version of the Concourse chart ([conco
 - [Web](#web)
 - [Workers](#workers)
   - [Adding external workers](#adding-external-workers)
+- [Deploying](#deploying)
 - [Metrics](#metrics)
 - [Logs](#logs)
 - [Accessing debug endpoints](#accessing-debug-endpoints)
@@ -75,6 +76,10 @@ You can add a reference to the new key as follows:
 ```
 
 *(yes, this will get better soon)*
+
+## Deploying
+
+To deploy hush-house, run `make deploy-hush-house`. If you want to force a rolling update (recreate all pods), say after updating secrets, then increment the `rollingUpdate` annotation declared in `values.yaml` for whichever component (web/worker) that you need to update.
 
 
 ## Metrics

--- a/deployments/with-creds/hush-house/README.md
+++ b/deployments/with-creds/hush-house/README.md
@@ -1,6 +1,6 @@
 # hush-house
 
-The `hush-house` deployment is responsible for the Concourse environment running under the publicly accessible URL https://hush-house.concourse-ci.org.
+The `hush-house` deployment is responsible for the Concourse environment running under the publicly accessible URL https://hush-house.pivotal.io.
 
 It relies solely on the release-candidate version of the Concourse chart ([concourse/charts](https://github.com/concourse/charts/tree/gh-pages)), and Kubernetes (k8s) objects (`ConfigMap`s) created by Helm templating files under [`./templates`](./templates).
 

--- a/deployments/with-creds/hush-house/requirements.lock
+++ b/deployments/with-creds/hush-house/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: concourse
-  repository: https://raw.githubusercontent.com/concourse/charts/gh-pages/
-  version: 0.0.139
-digest: sha256:9f47c990df8b789418766d1f52f460e275dc13b488544fefcad645527d8a418c
-generated: 2019-03-03T09:22:22.25931-05:00
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 5.1.2
+digest: sha256:765183e3009500fc04f970c8897f078742530b60be305ab3eef230194d7b1bef
+generated: 2019-04-16T10:34:20.947878-04:00

--- a/deployments/with-creds/hush-house/requirements.yaml
+++ b/deployments/with-creds/hush-house/requirements.yaml
@@ -1,5 +1,5 @@
 ---
 dependencies:
 - name: concourse
-  version: 0.0.139
-  repository: https://raw.githubusercontent.com/concourse/charts/gh-pages/
+  version: 5.1.2
+  repository: https://kubernetes-charts.storage.googleapis.com/

--- a/deployments/with-creds/hush-house/values.yaml
+++ b/deployments/with-creds/hush-house/values.yaml
@@ -14,8 +14,10 @@ concourse:
       size: 500Gi
 
   worker:
+    annotations:
+      rollingUpdate: "1"
     replicas: 4
-    terminationGracePeriodSeconds: 6000
+    terminationGracePeriodSeconds: 10000
     livenessProbe:
       periodSeconds: 60
       timeoutSeconds: 30
@@ -32,6 +34,8 @@ concourse:
         memory: 29Gi
 
   web:
+    annotations:
+      rollingUpdate: "1"
     replicas: 2
     nodeSelector: { cloud.google.com/gke-nodepool: generic-1 }
     affinity:

--- a/deployments/with-creds/hush-house/values.yaml
+++ b/deployments/with-creds/hush-house/values.yaml
@@ -68,7 +68,7 @@ concourse:
       containerPlacementStrategy: random
       enableGlobalResources: true
       encryption: { enabled: true }
-      externalUrl: https://hush-house.concourse-ci.org
+      externalUrl: https://hush-house.pivotal.io
       kubernetes: { keepNamespaces: true }
       metrics: { captureErrorMetrics: true }
       prometheus: { enabled: true }

--- a/helm/bootstrap-k8s-secrets.sh
+++ b/helm/bootstrap-k8s-secrets.sh
@@ -8,7 +8,7 @@
 # This is needed so that the `deploy` pipeline[1] can
 # make use of Helm with `--tls`.
 #
-# [1]: https://hush-house.concourse-ci.org/teams/main/pipelines/deploy
+# [1]: https://hush-house.pivotal.io/teams/main/pipelines/deploy
 #
 
 set -o errexit


### PR DESCRIPTION
All tasks from #25 have been completed.

- Changed from concourse-ci.org to pivotal.io
- Updated chart to use the latest helm repo
- removed requirements.lock file and added it to `.gitignore`
- Added web annotation to force recreate web pods on chart change

cc @taylorsilva 