### PR TITLE
hh: add `make set-teams` to set all teams configured

### DIFF
--- a/deployments/with-creds/hush-house/Makefile
+++ b/deployments/with-creds/hush-house/Makefile
@@ -1,0 +1,16 @@
+TEAMS = $(shell ls ./teams)
+
+# Performs a `fly set-team` for each team in the list of
+# teams defined under `./teams`.
+#
+# ps.: you must be already logged in, having a target named
+# `hh` whose default team is `main`.
+#
+set-teams: $(addprefix set-team-, $(TEAMS))
+
+set-team-%:
+	fly --target hh \
+		set-team \
+		--non-interactive \
+		--team-name=$* \
+		--config=./teams/$*

--- a/deployments/with-creds/hush-house/README.md
+++ b/deployments/with-creds/hush-house/README.md
@@ -9,6 +9,7 @@ It relies solely on the release-candidate version of the Concourse chart ([conco
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 
+- [Configuring teams](#configuring-teams)
 - [Web](#web)
 - [Workers](#workers)
   - [Adding external workers](#adding-external-workers)

--- a/deployments/with-creds/hush-house/README.md
+++ b/deployments/with-creds/hush-house/README.md
@@ -21,6 +21,32 @@ It relies solely on the release-candidate version of the Concourse chart ([conco
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
+## Configuring teams
+
+Every team configuration lives under the [`./teams`](./teams) directory.
+
+There you'll find on a per-team basis, files named after their corresponding team names - for instance, the `mycoolteam` team would have a file named `mycoolteam`.
+
+The contents of those `yaml` files are exactly the contents that goes into `fly set-team -c <config_file>` (see [Setting user roles](https://concourse-ci.org/managing-teams.html#setting-roles)).
+
+To have all of the teams set up:
+
+1. have the `hh` target configured with the `main` team:
+
+```sh
+fly --target hh login \
+  --team-name=main \
+  --concourse-url=https://hush-house.pivotal.io
+```
+
+2. Run the script that sets all teams:
+
+**WARNING** - this WILL NOT ask for a confirmation before running.
+
+```sh
+make set-teams
+```
+
 
 ## Web
 

--- a/deployments/with-creds/hush-house/teams/cf-notifications
+++ b/deployments/with-creds/hush-house/teams/cf-notifications
@@ -1,0 +1,8 @@
+# vim: set syntax=yaml:
+
+roles:
+  - name: owner
+    github:
+      teams:
+        - 'cloudfoundry-incubator:cf-notifications'
+        - 'concourse:pivotal'

--- a/deployments/with-creds/hush-house/teams/cf-tools
+++ b/deployments/with-creds/hush-house/teams/cf-tools
@@ -1,0 +1,8 @@
+# vim: set syntax=yaml:
+
+roles:
+  - name: owner
+    github:
+      teams:
+        - 'cloudfoundry-incubator:cf-notifications'
+        - 'concourse:pivotal'

--- a/deployments/with-creds/hush-house/teams/cf-tools
+++ b/deployments/with-creds/hush-house/teams/cf-tools
@@ -4,5 +4,5 @@ roles:
   - name: owner
     github:
       teams:
-        - 'cloudfoundry-incubator:cf-notifications'
+        - 'pivotal:strabo'
         - 'concourse:pivotal'

--- a/deployments/with-creds/hush-house/teams/examples
+++ b/deployments/with-creds/hush-house/teams/examples
@@ -1,0 +1,6 @@
+# vim: set syntax=yaml:
+
+roles:
+  - name: owner
+    github:
+      teams: [ 'concourse:pivotal' ]


### PR DESCRIPTION
On Wings, operators needed to manually set the configuration for the
teams that were part of the cluster.

By having all of the configuration in the repository, we're able to
automate that process, allowing other teams to go through the flow of
submitting a PR with what they want configured, freeing us from having
to manually do that.

This is what could be the first step to having such part automated.

Signed-off-by: Ciro S. Costa <cscosta@pivotal.io>