### PR TITLE
switch hush-house workers to use ubuntu

### DIFF
--- a/terraform/cluster/main.tf
+++ b/terraform/cluster/main.tf
@@ -38,10 +38,6 @@ resource "google_container_cluster" "main" {
     horizontal_pod_autoscaling {
       disabled = false
     }
-
-    kubernetes_dashboard {
-      disabled = false
-    }
   }
 
   master_auth {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -56,7 +56,7 @@ module "cluster" {
       auto-upgrade = false
       disk-size    = "50"
       disk-type    = "pd-ssd"
-      image        = "COS"
+      image        = "ubuntu"
       local-ssds   = 0
       machine-type = "custom-8-16384"
       max          = 20

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -91,7 +91,7 @@ module "database" {
 
   name         = "hush-house"
   cpus         = "4"
-  disk_size_gb = "20"
+  disk_size_gb = "25"
   memory_mb    = "5120"
   region       = "${var.region}"
   zone         = "${var.zone}"


### PR DESCRIPTION
We had a request from an internal team to use the `cifs` kernel module to allow them to mount SMB volumes. Even though their workload was privileged, they were not able to inject the `cifs` module into COS, so we will use Ubuntu on the k8s nodes to accomodate them.