### PR TITLE
pin the google providers in terraform

### DIFF
--- a/terraform/gcp.tf
+++ b/terraform/gcp.tf
@@ -4,6 +4,10 @@ terraform {
     bucket      = "concourse-hush-house"
     prefix      = "terraform-k8s/state"
   }
+  required_providers {
+    google = "~> 2"
+    google-beta = "~> 2"
+  }
 }
 
 provider "google" {


### PR DESCRIPTION
the mainline version points to 3.0-beta.1 which can't resolve our existing dns resources.
