### PR TITLE
Scale hush house

### DIFF
--- a/deployments/with-creds/hush-house/values.yaml
+++ b/deployments/with-creds/hush-house/values.yaml
@@ -19,7 +19,7 @@ concourse:
   web:
     annotations:
       rollingUpdate: "1"
-    replicas: 2
+    replicas: 3
     nodeSelector: { cloud.google.com/gke-nodepool: generic-1 }
     affinity:
       podAntiAffinity:

--- a/terraform/database/main.tf
+++ b/terraform/database/main.tf
@@ -27,6 +27,11 @@ resource "google_sql_database_instance" "main" {
       value = "-1"
     }
 
+    database_flags {
+      name  = "max_connections"
+      value = "${var.max_connections}"
+    }
+
     ip_configuration {
       ipv4_enabled = "true"
       require_ssl  = "true"

--- a/terraform/database/variables.tf
+++ b/terraform/database/variables.tf
@@ -27,3 +27,8 @@ variable "disk_size_gb" {
   default     = ""
   description = "The disk size in GB's (e.g. 10)"
 }
+
+variable "max_connections" {
+  default     = ""
+  description = "The max number of connections allowed by postgres"
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -89,12 +89,13 @@ module "cluster" {
 module "database" {
   source = "./database"
 
-  name         = "hush-house"
-  cpus         = "4"
-  disk_size_gb = "25"
-  memory_mb    = "5120"
-  region       = "${var.region}"
-  zone         = "${var.zone}"
+  name            = "hush-house"
+  cpus            = "4"
+  disk_size_gb    = "25"
+  memory_mb       = "5120"
+  region          = "${var.region}"
+  zone            = "${var.zone}"
+  max_connections = "300"
 }
 
 # Creates the CloudSQL Postgres database to be used by the `ci`
@@ -103,10 +104,11 @@ module "database" {
 module "ci-database" {
   source = "./database"
 
-  name         = "ci"
-  cpus         = "4"
-  disk_size_gb = "20"
-  memory_mb    = "5120"
-  region       = "${var.region}"
-  zone         = "${var.zone}"
+  name            = "ci"
+  cpus            = "4"
+  disk_size_gb    = "20"
+  memory_mb       = "5120"
+  region          = "${var.region}"
+  zone            = "${var.zone}"
+  max_connections = "100"
 }


### PR DESCRIPTION
We scaled hush house from 2 -> 3 nodes, and in doing so we needed to also increase the max_connections to the db.