### PR TITLE
add ci monitoring worker

### DIFF
--- a/deployments/with-creds/ci-monitoring/Chart.yaml
+++ b/deployments/with-creds/ci-monitoring/Chart.yaml
@@ -1,0 +1,8 @@
+name: ci
+apiVersion: v1
+version: 0.1.1
+appVersion: 0.0.139
+description: A Concourse worker deployment for team `monitoring-hush-house`
+maintainers:
+- name: ryang
+  email: ryang@pivotal.io

--- a/deployments/with-creds/ci-monitoring/README.md
+++ b/deployments/with-creds/ci-monitoring/README.md
@@ -1,0 +1,23 @@
+# ci-monitoring
+
+The `ci-monitoring` deployment deploys the worker that assign to team `monitoring-hush-house`
+for running hush-house.pivotal.io monitoring loads.
+
+It relies solely on the [Concourse chart](https://github.com/concourse/concourse-chart).
+
+## Deploying
+
+To deploy these workers, run `make deploy-ci-monitoring` from `/deployments/with-creds`.
+
+If you want to force a rolling update (recreate all pods), say after updating
+secrets, increment the `rollingUpdate` annotation declared in [`values.yaml`].
+
+[`values.yaml`]: ./values.yaml
+
+
+## Debugging
+
+Metrics, logs, and debug endpoints work the same as for the [`ci`] deployment.
+Check that deployment's README to know more.
+
+[`ci`]: ../ci

--- a/deployments/with-creds/ci-monitoring/requirements.lock
+++ b/deployments/with-creds/ci-monitoring/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: concourse
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 8.2.7
+digest: sha256:cb825c3e6f195eb63ddf2401a73ce01bb9852d28cc8bb309b40e9f1393eaec00
+generated: "2019-10-16T08:08:05.20907-04:00"

--- a/deployments/with-creds/ci-monitoring/requirements.yaml
+++ b/deployments/with-creds/ci-monitoring/requirements.yaml
@@ -1,0 +1,5 @@
+---
+dependencies:
+- name: concourse
+  version: 8.2.7
+  repository: https://kubernetes-charts.storage.googleapis.com/

--- a/deployments/with-creds/ci-monitoring/values.yaml
+++ b/deployments/with-creds/ci-monitoring/values.yaml
@@ -1,0 +1,50 @@
+postgresql:
+  enabled: false
+
+concourse:
+  image: concourse/concourse
+  imageDigest: sha256:e93a0149e3efe9186e403a188066c93a96ea2f223b24d49952275b63dc3e2c4d
+
+  postgresql:
+    enabled: false
+
+  web:
+    enabled: false
+
+  persistence:
+    worker:
+      storageClass: ssd
+      size: 750Gi
+
+  worker:
+    replicas: 1
+    terminationGracePeriodSeconds: 3600
+    livenessProbe:
+      periodSeconds: 60
+      failureThreshold: 10
+      timeoutSeconds: 45
+    nodeSelector: { cloud.google.com/gke-nodepool: ci-workers-monitoring }
+    hardAntiAffinity: true
+    env:
+    - name: CONCOURSE_GARDEN_NETWORK_POOL
+      value: "10.254.0.0/16"
+    - name: CONCOURSE_GARDEN_MAX_CONTAINERS
+      value: "500"
+    - name: CONCOURSE_GARDEN_DENY_NETWORK
+      value: "169.254.169.254/32"
+    resources:
+      limits:   { cpu: 7500m, memory: 14Gi }
+      requests: { cpu: 0m,    memory: 0Gi  }
+
+  concourse:
+    worker:
+      rebalanceInterval: 2h
+      baggageclaim: { driver: overlay }
+      team: "monitoring-hush-house"
+      healthcheckTimeout: 40s
+      tsa:
+        hosts: ['ci-web.ci.svc.cluster.local:2222']
+
+  secrets:
+    hostKeyPub: |-
+      ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDiMRfkctT6v/KWRAQGZtICcWp6IToTSZ60siycdLHlBHAJtqGloj+C/rhFikEXmITfOi14lfTqVfbgjXoP1QURbtpXDgdmMxYznztj5t5nNPjwWtlbGqwHibmAigEIMwICYHY/LUqKYXD1DVAP/AYFqb7QCF+s5t4jTjnlYWldncFjNoiR3f4XB3/Bz/BVVL8WSLNkCSb8gUN3H6+tCCGLz91dcNXT8t1H39h+/PskqrNaU+BKF1NJrNHii7DNXTUoagiXDGVH1/TMn211jksJ0TjVgY2dmGO7VRAo4AE03xxFaNg6gcD0jwwPjTFGDAt8p+J/1a8JzdBRCc9ogiSEOe/AxJHMDyi5twP4s8P8f1KjnZzJJ145SKGy3Rv7/JofKSLr2tAID5963HEUZeXIA4tLmXoiQc7w8zV9wWEf7h5Mrf2bLOfDfodghXq+olpFsrkGZGlMLszBggp86ZaECR6AzDlhl9v9PMARbZmNdaH10cI5wiMExH/O4lakXC6Z+CVOaYUBp80oh/kqlADbN4lYYVyvWodGpLAbHWzQpPNooyu2GHERyNGLWssFaByDPV0G3qnRfFAvExwHjL53U0uztOFE7w9KXYWuQB0B7ZCLCeC1QQ1iUSafnS5dJYu0fivAzezopSA/UqezKKA58Mud8SraJXEQ1C5//oR4sQ==

--- a/deployments/with-creds/ci/values.yaml
+++ b/deployments/with-creds/ci/values.yaml
@@ -5,6 +5,11 @@ concourse:
   image: concourse/concourse
   imageTag: 5.7.2
 
+  secrets:
+    teamAuthorizedKeys:
+    - team: monitoring-hush-house
+      key: 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDP5oT2CUJgRP55iNQD7NK4JzxRHSKstRXAV9EJw6O2Iaf9D9foHOaYNpgeIrRW4sbGvucLMhOBchp7yOhPTxn9jCUIGQttAWnFWW9SeHYOwPmbC30ggIIKmUQ/oWC6Xxou+KPotmqkKv+YyxNh8otTY5Sbz8VodEVqYR4hgXqunbSlcYJdMJqt6w0R319INdd898o6MbRrO5tj2I0ej8/Ct/n8Ijliawj3Mlm3g3w0O31C/Aj9jpEyvt+7JfcRWeJ1VcEnDsy4/UTqLh8P46LX/vzPQoPp54qrSaMcN7/1ylqn8XG5g+QWH4rmyJhH+0d1bt4v05M8b/UuHdXHgXVDMYyIFbvz2hRdhX7ZSHtP48e1B9t1S5Uo9gPG4D0jkWdMkpQf8/b4PXNF4nmBdKcWp9DqfYZOBMM17ZckOoWTnIORuZ/Xzgk1k11k0yAwRDxEksQuTSQexf5zxnku3ZediR5CwdbY9w4NiYB0DVCK7ktPi7Yg6RPrDgfALdB4vIg6jcWI3xw0ot2XVpZ2MGmUxL+ZlsymYncQ5p3pHRbznWbR2piniCa4rbE/KP0zFTDrNIMp2433nI0q5P1WbNuOQkL/XOIFkNr6f81ra9XJZWsV4Ytozivi5cg7hiPgCgxfUpnAQ+7NsSFYnV/gmmLjKUVCsdEwxqH5IxlxMYJqlQ=='
+
   postgresql:
     enabled: false
 


### PR DESCRIPTION
fixes https://github.com/concourse/prod/issues/42

CI pipeline [monitoring-stats](https://nci.concourse-ci.org/teams/monitoring-hush-house/pipelines/monitoring-stats) uder team `monitoring-hush-house` is now running in a team worker that deployed by the changes of this PR. 