### PR TITLE
enable postgres as the backend of `vault`

### DIFF
--- a/deployments/with-creds/vault/README.md
+++ b/deployments/with-creds/vault/README.md
@@ -2,14 +2,12 @@
 
 1. ~Clone [vault-helm](https://github.com/hashicorp/vault-helm) into charts/vault-helm and checkout the version referenced in `requirements.yaml`~
 1. We have a forked version of [vault-helm](https://github.com/concourse/vault-helm). Which has something special for the postgres backend. Please keep using this version until it gets merged back to `vault-helm` chart.
-1. `vault-nci` and `vault` are alive at the same time so far. `vault` may decommission in the future after `vault-nci` is all set.
-1. How to deploy `vault-nci`
+1. How to deploy `vault`
     1. `git clone https://github.com/concourse/vault-helm` to the `charts` (hush-house/deployments/with-creds/vault/charts) directory.
-    1 `ln -s vault vault-nci` 
-    1. `make creds-vault-nci`
-    1. `make deploy-vault-nci`. If you get the error `app-name has no deployed releases`, delete the deployment with the command `helm delete --purge vault-nci --tls`, then try again.
+    1. `make creds-vault`
+    1. `make deploy-vault`. If you get the error `app-name has no deployed releases`, delete the deployment with the command `helm delete --purge vault --tls`, then try again.
 1. Verify
-    1. You should be able to login in to the container with the command `kubectl exec -it -n vault-nci vault-nci-0 /bin/sh`
+    1. You should be able to login in to the container with the command `kubectl exec -it -n vault vault-0 /bin/sh`
     1. `export VAULT_SKIP_VERIFY=true`
     1. `vault status`.
         ```

--- a/deployments/with-creds/vault/README.md
+++ b/deployments/with-creds/vault/README.md
@@ -1,3 +1,29 @@
 # Setup
 
-1. Clone [vault-helm](https://github.com/hashicorp/vault-helm) into charts/vault-helm and checkout the version referenced in `requirements.yaml`
+1. ~Clone [vault-helm](https://github.com/hashicorp/vault-helm) into charts/vault-helm and checkout the version referenced in `requirements.yaml`~
+1. We have a forked version of [vault-helm](https://github.com/concourse/vault-helm). Which has something special for the postgres backend. Please keep using this version until it gets merged back to `vault-helm` chart.
+1. `vault-nci` and `vault` are alive at the same time so far. `vault` may decommission in the future after `vault-nci` is all set.
+1. How to deploy `vault-nci`
+    1. `git clone https://github.com/concourse/vault-helm` to the `charts` (hush-house/deployments/with-creds/vault/charts) directory.
+    1 `ln -s vault vault-nci` 
+    1. `make creds-vault-nci`
+    1. `make deploy-vault-nci`. If you get the error `app-name has no deployed releases`, delete the deployment with the command `helm delete --purge vault-nci --tls`, then try again.
+1. Verify
+    1. You should be able to login in to the container with the command `kubectl exec -it -n vault-nci vault-nci-0 /bin/sh`
+    1. `export VAULT_SKIP_VERIFY=true`
+    1. `vault status`.
+        ```
+        Key                      Value
+        ---                      -----
+        Recovery Seal Type       shamir
+        Initialized              true
+        Sealed                   false
+        Total Recovery Shares    5
+        Threshold                3
+        Version                  1.2.4
+        Cluster Name             vault-cluster-1c5d79f5
+        Cluster ID               2d6904b1-04ff-xxxx-xxxx-01fc92f15795
+        HA Enabled               false
+        ```
+    1. `vault list /concourse/main`. You should see those credentials.
+

--- a/deployments/with-creds/vault/templates/vault-tls-secret.yml
+++ b/deployments/with-creds/vault/templates/vault-tls-secret.yml
@@ -9,3 +9,5 @@ data:
   vault.crt: {{ default "" .Values.vault.crt | b64enc | quote }}
   vault.key: {{ default "" .Values.vault.key | b64enc | quote }}
   {{- end }}
+  vault.ip: {{ default "" .Values.vault.ip | b64enc | quote }}
+  vault.secret: {{ default "" .Values.vault.secret | b64enc | quote }}

--- a/deployments/with-creds/vault/values.yaml
+++ b/deployments/with-creds/vault/values.yaml
@@ -23,11 +23,11 @@ vault:
           tls_client_ca_file = "/vault/userconfig/vault-server-tls/vault.ca"
         }
 
-        storage "file" {
-          path = "/vault/data"
+        storage "postgresql" {
+          connection_url = "host=%VAULT_IP% port=5432 user=atc password=%VAULT_SECRET% sslkey=/home/vault/vault-server-tls/vault.key sslcert=/home/vault/vault-server-tls/vault.crt sslrootcert=/home/vault/vault-server-tls/vault.ca dbname=vault"
         }
 
         seal "gcpckms" {
-          key_ring = "vault-helm-unseal-kr"
-          crypto_key = "vault-helm-unseal-key"
+          key_ring = "vault-helm-unseal-kr-nci"
+          crypto_key = "vault-helm-unseal-key-nci"
         }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -174,3 +174,38 @@ resource "google_kms_crypto_key" "vault-helm-unseal-key" {
     prevent_destroy = true
   }
 }
+
+# gkms key for vault-nci unseal
+# Concourse deployment.
+#
+resource "google_kms_key_ring" "keyring-nci" {
+  name     = "vault-helm-unseal-kr-nci"
+  location = "global"
+}
+
+# crypto key for vault-nci unseal
+# Concourse deployment.
+#
+resource "google_kms_crypto_key" "vault-helm-unseal-key-nci" {
+  name            = "vault-helm-unseal-key-nci"
+  key_ring        = google_kms_key_ring.keyring-nci.self_link
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# Creates the CloudSQL Postgres database to be used by the `vault`
+# Concourse deployment.
+#
+ module "vault-database" {
+  source = "./database"
+
+  name            = "vault"
+  cpus            = "4"
+  disk_size_gb    = "10"
+  memory_mb       = "5120"
+  region          = "${var.region}"
+  zone            = "${var.zone}"
+  max_connections = "100"
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -48,6 +48,31 @@ output "ci-database-private-key" {
   value     = "${module.ci-database.private-key}"
 }
 
+# vault database outputs
+output "vault-database-ip" {
+  value = "${module.vault-database.ip}"
+}
+
+output "vault-database-ca-cert" {
+  sensitive = true
+  value     = "${module.vault-database.ca-cert}"
+}
+
+output "vault-database-password" {
+  sensitive = true
+  value     = "${module.vault-database.password}"
+}
+
+output "vault-database-cert" {
+  sensitive = true
+  value     = "${module.vault-database.cert}"
+}
+
+output "vault-database-private-key" {
+  sensitive = true
+  value     = "${module.vault-database.private-key}"
+}
+
 output "hush-house-address" {
   value = "${google_compute_address.hush-house.address}"
 }


### PR DESCRIPTION
Fixes: https://github.com/concourse/prod/issues/44

**This PR can work with the forked repo: https://github.com/concourse/vault-helm**
We are going to draft a PR for that later.

I created a new vault - `vault-nci` for test, resilience and migration purpose.
the steps are as below:
- `ln -s vault vault-nci`
- `make creds-vault-nci`
- `make deploy-vault-nci`

## You can review the PR, but DO NOT Merge the PR until the data migration is done.