### PR TITLE
enable auto-unseal with leveraging gkms

### DIFF
--- a/deployments/with-creds/vault/templates/vault-gcp.yml
+++ b/deployments/with-creds/vault/templates/vault-gcp.yml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vault-gcp
+type: Opaque
+data:
+  vault.gcp: {{ default "" .Values.vault.gcp | b64enc | quote }}
+

--- a/deployments/with-creds/vault/values.yaml
+++ b/deployments/with-creds/vault/values.yaml
@@ -6,6 +6,12 @@ vault:
     extraVolumes:
       - type: secret
         name: vault-server-tls
+      - type: secret
+        name: vault-gcp
+    extraEnvironmentVars:
+      GOOGLE_REGION: global
+      GOOGLE_PROJECT: cf-concourse-production
+      GOOGLE_APPLICATION_CREDENTIALS: /vault/userconfig/vault-gcp/vault.gcp
     standalone:
       enabled: true
       config: |
@@ -19,4 +25,9 @@ vault:
 
         storage "file" {
           path = "/vault/data"
+        }
+
+        seal "gcpckms" {
+          key_ring = "vault-helm-unseal-kr"
+          crypto_key = "vault-helm-unseal-key"
         }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -154,3 +154,23 @@ module "ci-database" {
   zone            = "${var.zone}"
   max_connections = "100"
 }
+
+# gkms key for vault unseal
+# Concourse deployment.
+#
+resource "google_kms_key_ring" "keyring" {
+  name     = "vault-helm-unseal-kr"
+  location = "global"
+}
+
+# crypto key for vault unseal
+# Concourse deployment.
+#
+resource "google_kms_crypto_key" "vault-helm-unseal-key" {
+  name            = "vault-helm-unseal-key"
+  key_ring        = google_kms_key_ring.keyring.self_link
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}


### PR DESCRIPTION
fixes: https://github.com/concourse/prod/issues/48
The process for auto-unseal:
- `terraform apply`. if it is failed with `403`, open the `gcp` console to grant the access that error descripted.
- merge PR https://github.com/concourse/hush-house/pull/87 
- `helm deploy` (for this case it is `make deploy-vault-nci`). Be aware we are in the `ln -s vault vault-nci` directory. We do not want to overwrite the existed `vault` after we migrate the secrets.
- `vault init`
  - `kubectl -n vault-nci exec -it vault-nci-0 /bin/sh` to login to `vault` container.
  -  `export VAULT_SKIP_VERIFY=1`
  -  `vault init`
  -  log the credentials into `lastpass`
- verify
  - `vault login` with the secret that your save in the last step.
  - `vault secrets enable -path=/concourse kv`
  -  `vault write /concourse/test key1=12345`
  -  `kubectl delete pod vault-nci-0 -n vault-nci`
  -   `kubectl -n vault-nci exec -it vault-nci-0 /bin/sh` to login to `vault` container.
  -  `vault status` you should see:
      ```
      Key                      Value
      ---                      -----
      Recovery Seal Type       shamir
      Initialized              true
      Sealed                   false
      Total Recovery Shares    5
      Threshold                3
      Version                  1.2.4
      Cluster Name             vault-cluster-d2c84530
      Cluster ID               972... ........33037b9
      HA Enabled               false
      ```
      The `Sealed` should be false
  -  `vault login`
  -  `vault read /concourse/test`
      ```
      Key                 Value
      ---                 -----
      refresh_interval    768h
      key1                12345
      ```