### PR TITLE
Ci topgun worker

### DIFF
--- a/deployments/with-creds/ci-topgun/Chart.yaml
+++ b/deployments/with-creds/ci-topgun/Chart.yaml
@@ -1,0 +1,12 @@
+name: ci-topgun
+apiVersion: v1
+version: 0.1.1
+appVersion: 0.0.139
+description: A Concourse deployment used by Concourse to ship Concourse
+maintainers:
+- name: cirocosta
+  email: cscosta@pivotal.io
+- name: kmannem
+  email: kmannem@pivotal.io
+- name: svohra
+  email: svohra@pivotal.io

--- a/deployments/with-creds/ci-topgun/README.md
+++ b/deployments/with-creds/ci-topgun/README.md
@@ -1,0 +1,20 @@
+# ci-topgun
+
+The `ci-topgun` deployment deploys the worker used to run the `k8s-topgun` test suite.
+The test suite can be triggered in a few places:
+
+- The main Concourse pipeline or any of the `release/#.#.x` pipelines
+- The `helm-prs...` pipelines
+
+It relies solely on the [Concourse chart](https://github.com/concourse/concourse-chart).
+
+## Deploying
+
+To deploy these workers:
+
+- `kubectl config use-context topgun` to deploy to the `topgun` cluster on GKE
+- ~run `make deploy-ci-topgun-worker` from `/deployments/with-creds`.~ **TODO: `make` method doesn't work because of `--tls`**
+  - `cd ci-topgun && helm upgrade --install --namespace=ci-topgun --values=./.values.yaml --wait ci-topgun .`
+
+If you want to force a rolling update (recreate all pods), say after updating
+secrets, increment the `rollingUpdate` annotation declared in [`values.yaml`].

--- a/deployments/with-creds/ci-topgun/requirements.lock
+++ b/deployments/with-creds/ci-topgun/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: concourse
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 8.2.7
+digest: sha256:cb825c3e6f195eb63ddf2401a73ce01bb9852d28cc8bb309b40e9f1393eaec00
+generated: "2019-10-16T08:08:05.20907-04:00"

--- a/deployments/with-creds/ci-topgun/requirements.yaml
+++ b/deployments/with-creds/ci-topgun/requirements.yaml
@@ -1,0 +1,5 @@
+---
+dependencies:
+- name: concourse
+  version: 8.2.7
+  repository: https://kubernetes-charts.storage.googleapis.com/

--- a/deployments/with-creds/ci-topgun/templates/NOTES.txt
+++ b/deployments/with-creds/ci-topgun/templates/NOTES.txt
@@ -1,0 +1,1 @@
+Take off!

--- a/deployments/with-creds/ci-topgun/values.yaml
+++ b/deployments/with-creds/ci-topgun/values.yaml
@@ -1,0 +1,52 @@
+postgresql:
+  enabled: false
+
+concourse:
+  image: concourse/concourse
+  imageDigest: sha256:e93a0149e3efe9186e403a188066c93a96ea2f223b24d49952275b63dc3e2c4d
+
+  postgresql:
+    enabled: false
+
+  web:
+    enabled: false
+
+  persistence:
+    worker:
+      storageClass: ssd
+      size: 100Gi
+
+  worker:
+    replicas: 1
+    annotations:
+      rollingUpdate: "1"
+    terminationGracePeriodSeconds: 3600
+    livenessProbe:
+      periodSeconds: 60
+      failureThreshold: 10
+      timeoutSeconds: 45
+    nodeSelector: { cloud.google.com/gke-nodepool: topgun-worker }
+    hardAntiAffinity: true
+    env:
+    - name: CONCOURSE_GARDEN_NETWORK_POOL
+      value: "10.254.0.0/16"
+    - name: CONCOURSE_GARDEN_MAX_CONTAINERS
+      value: "500"
+    - name: CONCOURSE_GARDEN_DENY_NETWORK
+      value: "169.254.169.254/32"
+    resources:
+      limits:   { cpu: 7500m, memory: 14Gi }
+      requests: { cpu: 0m,    memory: 0Gi  }
+
+  concourse:
+    worker:
+      rebalanceInterval: 2h
+      baggageclaim: { driver: overlay }
+      tag: "k8s-topgun"
+      healthcheckTimeout: 40s
+      tsa:
+        hosts: ['nci.concourse-ci.org:2222']
+
+  secrets:
+    hostKeyPub: |-
+      ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDiMRfkctT6v/KWRAQGZtICcWp6IToTSZ60siycdLHlBHAJtqGloj+C/rhFikEXmITfOi14lfTqVfbgjXoP1QURbtpXDgdmMxYznztj5t5nNPjwWtlbGqwHibmAigEIMwICYHY/LUqKYXD1DVAP/AYFqb7QCF+s5t4jTjnlYWldncFjNoiR3f4XB3/Bz/BVVL8WSLNkCSb8gUN3H6+tCCGLz91dcNXT8t1H39h+/PskqrNaU+BKF1NJrNHii7DNXTUoagiXDGVH1/TMn211jksJ0TjVgY2dmGO7VRAo4AE03xxFaNg6gcD0jwwPjTFGDAt8p+J/1a8JzdBRCc9ogiSEOe/AxJHMDyi5twP4s8P8f1KjnZzJJ145SKGy3Rv7/JofKSLr2tAID5963HEUZeXIA4tLmXoiQc7w8zV9wWEf7h5Mrf2bLOfDfodghXq+olpFsrkGZGlMLszBggp86ZaECR6AzDlhl9v9PMARbZmNdaH10cI5wiMExH/O4lakXC6Z+CVOaYUBp80oh/kqlADbN4lYYVyvWodGpLAbHWzQpPNooyu2GHERyNGLWssFaByDPV0G3qnRfFAvExwHjL53U0uztOFE7w9KXYWuQB0B7ZCLCeC1QQ1iUSafnS5dJYu0fivAzezopSA/UqezKKA58Mud8SraJXEQ1C5//oR4sQ==

--- a/deployments/with-creds/ci-topgun/values.yaml
+++ b/deployments/with-creds/ci-topgun/values.yaml
@@ -19,7 +19,7 @@ concourse:
   worker:
     replicas: 1
     annotations:
-      rollingUpdate: "1"
+      rollingUpdate: "2"
     terminationGracePeriodSeconds: 3600
     livenessProbe:
       periodSeconds: 60
@@ -42,6 +42,8 @@ concourse:
     worker:
       rebalanceInterval: 2h
       baggageclaim: { driver: overlay }
+      garden:
+        dnsProxyEnable: "false"
       tag: "k8s-topgun"
       healthcheckTimeout: 40s
       tsa:


### PR DESCRIPTION
This PR adds a new chart that is used to deploy an external concourse worker
that connects to our ci (prod) environment. It tags itself with
`k8s-topgun` and is to be used for running the k8s-topgun test suite within a k8s cluster.

This deployment is different from other deployments in this repo. All other
deployments assume you're targeting the hush-house GKE cluster.
Instead, this deployment is meant to go on the topgun GKE cluster and
onto the node pool named `topgun-worker`.

The creds (.value.yml) file is saved in lastpass like the rest of the
deployments in this repo.

Currently you can't use the `Makefile` to deploy because the hush-house GKE requires the `--tls` flag with all commands. The topgun GKE cluster does not require this. 