### PR TITLE
deployment/metrics: bump grafana and prometheus

### DIFF
--- a/deployments/with-creds/metrics/requirements.lock
+++ b/deployments/with-creds/metrics/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: prometheus
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 9.3.1
+  version: 9.7.2
 - name: grafana
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 4.0.4
-digest: sha256:926e89c882d860fabd502e9437853e03e0f34a46d9d5157a2a17335277f59bfc
-generated: "2019-11-22T15:18:47.470062-05:00"
+digest: sha256:943d97ad2570233208583756330d169e9721be37bd3420d984f3694031b9da27
+generated: "2020-01-02T15:23:32.812197-05:00"

--- a/deployments/with-creds/metrics/requirements.lock
+++ b/deployments/with-creds/metrics/requirements.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 9.7.2
 - name: grafana
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 4.0.4
-digest: sha256:943d97ad2570233208583756330d169e9721be37bd3420d984f3694031b9da27
-generated: "2020-01-02T15:23:32.812197-05:00"
+  version: 4.3.0
+digest: sha256:a6d57d5323e6f93fb80dd34ee9912a72357ddd9665892519ca9161410835a16b
+generated: "2020-01-02T15:26:54.372185-05:00"

--- a/deployments/with-creds/metrics/requirements.yaml
+++ b/deployments/with-creds/metrics/requirements.yaml
@@ -1,7 +1,7 @@
 ---
 dependencies:
 - name: prometheus
-  version: 9.3.1
+  version: 9.7.2
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: prometheus.enabled
 

--- a/deployments/with-creds/metrics/requirements.yaml
+++ b/deployments/with-creds/metrics/requirements.yaml
@@ -6,6 +6,6 @@ dependencies:
   condition: prometheus.enabled
 
 - name: grafana
-  version: 4.0.4
+  version: 4.3.0
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: grafana.enabled


### PR DESCRIPTION
grafana

    pretty much no k8s object changes on our side, aside from the bump in
    the version of grafana (going from `6.4.x` to `6.5.x`).

    there are no big new features for us on this one though - the "why" of
    this is just to keep us up to date

prometheus

    the bump brings no underlying app version changes, but instead, just
    chart updates: mostly, unused rbac objects getting removed - no
    functional changes to `prometheus` server itself.