### PR TITLE
deployments/metrics: increase prometheus retention

### DIFF
--- a/deployments/with-creds/metrics/values.yaml
+++ b/deployments/with-creds/metrics/values.yaml
@@ -22,6 +22,7 @@ prometheus:
     nodeSelector: { cloud.google.com/gke-nodepool: generic-1 }
 
   server:
+    retention: 60d
     nodeSelector: { cloud.google.com/gke-nodepool: generic-1 }
     persistentVolume:
       enabled: true


### PR DESCRIPTION
this change allows us to keep data collected by prometheus for much
longer:

```diff
          - name: prometheus-server
            image: "prom/prometheus:v2.13.1"
            imagePullPolicy: "IfNotPresent"
            args:
-             - --storage.tsdb.retention.time=15d
+             - --storage.tsdb.retention.time=60d
              - --config.file=/etc/config/prometheus.yml
              - --storage.tsdb.path=/data
              - --web.console.libraries=/etc/prometheus/console_libraries
              - --web.console.templates=/etc/prometheus/consoles
              - --web.enable-lifecycle
```

we're currently using ~3.3% of our persistent volume, so it should be
quit safe to perform a 4x increase.

Signed-off-by: Ciro S. Costa <cscosta@pivotal.io>