### PR TITLE
Bump the web memory

### DIFF
--- a/deployments/with-creds/hush-house/values.yaml
+++ b/deployments/with-creds/hush-house/values.yaml
@@ -47,10 +47,10 @@ concourse:
     resources:
       requests:
         cpu: 3000m
-        memory: 1Gi
+        memory: 2Gi
       limits:
         cpu: 3000m
-        memory: 1Gi
+        memory: 2Gi
 
   concourse:
     web:


### PR DESCRIPTION
The web nodes in hush-house were spiking beyond 1Gi and that was causing the pods to get killed with OOM. Going to bumping the limit will allow spikes to happen without the pod being killed!