### PR TITLE
ci: bumping version to 5.8.0-rc.15

### DIFF
--- a/deployments/with-creds/ci/values.yaml
+++ b/deployments/with-creds/ci/values.yaml
@@ -2,8 +2,8 @@ postgresql:
   enabled: false
 
 concourse:
-  image: concourse/concourse
-  imageTag: 5.8.0
+  image: concourse/concourse-rc
+  imageTag: 5.8.0-rc.15
 
   secrets:
     teamAuthorizedKeys:


### PR DESCRIPTION
Selected this version based on the commit
51a7cef83be3f7817e3b220d4b8a54dc3df3d0a2, before the merge of 6.0 changes.

Link to the build-rc-image job:
https://ci.concourse-ci.org/teams/main/pipelines/concourse/jobs/build-rc-image/builds/63

Signed-off-by: Izabela Gomes <igomes@pivotal.io>
Co-authored-by: Izabela Gomes <igomes@pivotal.io>