### PR TITLE
ci-monitoring: use containerd

### DIFF
--- a/deployments/with-creds/ci-monitoring/values.yaml
+++ b/deployments/with-creds/ci-monitoring/values.yaml
@@ -2,8 +2,9 @@ postgresql:
   enabled: false
 
 concourse:
-  image: concourse/concourse
-  imageDigest: sha256:e93a0149e3efe9186e403a188066c93a96ea2f223b24d49952275b63dc3e2c4d
+  image: cirocosta/concourse
+  imageTag: containerd
+  imagePullPolicy: Always
 
   postgresql:
     enabled: false
@@ -26,12 +27,10 @@ concourse:
     nodeSelector: { cloud.google.com/gke-nodepool: ci-workers-monitoring }
     hardAntiAffinity: true
     env:
-    - name: CONCOURSE_GARDEN_NETWORK_POOL
-      value: "10.254.0.0/16"
-    - name: CONCOURSE_GARDEN_MAX_CONTAINERS
-      value: "500"
-    - name: CONCOURSE_GARDEN_DENY_NETWORK
-      value: "169.254.169.254/32"
+    - name: CONCOURSE_GARDEN_USE_CONTAINERD
+      value: "true"
+    - name: CONCOURSE_GARDEN_BIN
+      value: "containerd"
     resources:
       limits:   { cpu: 7500m, memory: 14Gi }
       requests: { cpu: 0m,    memory: 0Gi  }
@@ -42,6 +41,8 @@ concourse:
       baggageclaim: { driver: overlay }
       team: "monitoring-hush-house"
       healthcheckTimeout: 40s
+      garden:
+        bin: containerd
       tsa:
         hosts: ['ci-web.ci.svc.cluster.local:2222']
 


### PR DESCRIPTION
experimenting with https://github.com/concourse/concourse/pull/5114

(changes are already applied)