### PR TITLE
allow github concourse contributor team to rerun builds

### DIFF
--- a/deployments/with-creds/ci/contributor-team-config.yml
+++ b/deployments/with-creds/ci/contributor-team-config.yml
@@ -1,0 +1,5 @@
+# fly -t ci set-team -n contributor --config contributor-team-config.yml
+roles:
+- name: pipeline-operator
+  github:
+    teams: ["concourse:contributors"]

--- a/deployments/with-creds/ci/contributor-team-config.yml
+++ b/deployments/with-creds/ci/contributor-team-config.yml
@@ -1,5 +1,8 @@
 # fly -t ci set-team -n contributor --config contributor-team-config.yml
 roles:
+- name: owner
+  github:
+    teams: ["concourse:pivotal"]
 - name: pipeline-operator
   github:
     teams: ["concourse:contributors"]

--- a/deployments/with-creds/ci/values.yaml
+++ b/deployments/with-creds/ci/values.yaml
@@ -87,6 +87,27 @@ concourse:
             team: concourse:Pivotal
         github:
           enabled: true
+      # so pipeline-operator ended up with two permissions
+      # - RerunJobBuild
+      # - CheckResource
+      # which will be granted to concourse:contributors for
+      # operating PR pipeline
+      configRBAC: |
+        member:
+        - AbortBuild
+        - CreateJobBuild
+        - PauseJob
+        - UnpauseJob
+        - ClearTaskCache
+        - UnpinResource
+        - SetPinCommentOnResource
+        - CheckResourceWebHook
+        - CheckResourceType
+        - EnableResourceVersion
+        - DisableResourceVersion
+        - PinResourceVersion
+        - PausePipeline
+        - UnpausePipeline
       bindPort: 80
       clusterName: ci
       containerPlacementStrategy: limit-active-tasks


### PR DESCRIPTION
once we have the pr bot working by https://github.com/concourse/concourse/pull/5564

then we need to config concourse production CI to allow members of concourse:contributor team to rerun failure PR pipeline builds(due to flaky test) and check PR resource(if desired version is not fetched)