### PR TITLE
ci: remove datadog; oc-agent scrapes prometheus

### DIFF
--- a/deployments/with-creds/ci/templates/ocagent-configmap.yml
+++ b/deployments/with-creds/ci/templates/ocagent-configmap.yml
@@ -12,11 +12,24 @@ data:
     receivers:
       jaeger:
         collector_http_port: 14268
+      prometheus:
+        config:
+          global:
+            scrape_interval: '5s'
+            evaluation_interval: '5s'
+          scrape_configs:
+            - job_name: 'concourse'
+              static_configs:
+                - targets:
+                  - 'localhost:9391'
     exporters:
       wavefront:
         enable_tracing: true
         application_name: concourse
         service_name: atc
+        custom_tags:
+        - "environment" : "ci"
         proxy:
           Host: 127.0.0.1
           TracingPort: 30000
+          MetricsPort: 2878

--- a/deployments/with-creds/ci/values.yaml
+++ b/deployments/with-creds/ci/values.yaml
@@ -32,6 +32,27 @@ concourse:
                 app: ci-web
                 release: ci
     sidecarContainers:
+      - name: telegraf
+        image: telegraf
+        volumeMounts:
+        - name: dsdsocket
+          mountPath: /var/run/datadog
+        command:
+        - /bin/bash
+        - -c
+        - |
+          echo '
+          [[inputs.prometheus]]
+            urls = ["http://127.0.0.1:9391"]
+            metric_version = 2
+            name_override = "concourse.ci"
+            [inputs.prometheus.tags]
+              environment = "ci"
+          [[outputs.datadog]]
+            url = unix:///var/run/datadog/dsd.socket
+          ' > /etc/telegraf/telegraf.conf
+
+          exec telegraf
       - name: oc-agent
         image: omnition/opencensus-agent:0.1.11
         volumeMounts:
@@ -145,8 +166,6 @@ concourse:
         keepNamespaces: false
         enabled: false
         createTeamNamespaces: false
-      metrics:
-        attribute: "environment:ci"
       tracing:
         jaegerEndpoint: http://127.0.0.1:14268/api/traces
       vault:
@@ -157,12 +176,8 @@ concourse:
         useCaCert: true
       letsEncrypt: { enabled: true, acmeURL: "https://acme-v02.api.letsencrypt.org/directory" }
       tls: { enabled: true, bindPort: 443 }
-      datadog:
+      prometheus:
         enabled: true
-
-        # horrible hack; we need a proper way to configure unix sockets
-        agentHost: unix
-        agentPort: ///var/run/datadog/dsd.socket
       postgres:
         host: 34.69.204.254
         database: atc


### PR DESCRIPTION
accordingly we should see metrics appearing in wavefront.