### PR TITLE
Enable secret redaction

### DIFF
--- a/deployments/with-creds/hush-house/values.yaml
+++ b/deployments/with-creds/hush-house/values.yaml
@@ -96,6 +96,7 @@ concourse:
       enableWorkerAuditing: true
       enableCacheStreamedVolumes: true
       enableResourceCausality: true
+      enableRedactSecrets: true
       baggageclaimResponseHeaderTimeout: 10m
       encryption: { enabled: true }
       externalUrl: https://hush-house.pivotal.io


### PR DESCRIPTION
It may seem useless at first to enable secret redaction without a cluster-wide credential manager, however with the addition of `var_sources` this is not necessarily true anymore.

It is possible to harness the `dummy` type for `var_sources` and get proper secret redaction in Concourse logs. See [**Examples** section from official docs](https://concourse-ci.org/vars.html#cluster-wide-credential-manager).

**WARNING**: this method does not replace the use of a credential-manager. Anyone with permission to run `fly get-pipeline` will be able to see your secrets in plain text. However, I believe this method provides a security improvement at a relatively small cost - (it [can affect performance](https://concourse-ci.org/creds-redacting.html#creds-redacting)).